### PR TITLE
Bump to v0.112

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.termux"
         minSdkVersion project.properties.minSdkVersion.toInteger()
         targetSdkVersion project.properties.targetSdkVersion.toInteger()
-        versionCode project.properties.termuxVersionCode.toInteger()
-        versionName project.properties.termuxVersion
+        versionCode 112
+        versionName "0.112"
 
         manifestPlaceholders.TERMUX_PACKAGE_NAME = "com.termux"
         manifestPlaceholders.TERMUX_APP_NAME = "Termux"

--- a/terminal-emulator/build.gradle
+++ b/terminal-emulator/build.gradle
@@ -63,7 +63,7 @@ publishing {
         bar(MavenPublication) {
             groupId 'com.termux'
             artifactId 'terminal-emulator'
-            version project.properties.termuxVersion
+            version "0.112"
             artifact(sourceJar)
             artifact("$buildDir/outputs/aar/terminal-emulator-release.aar")
         }

--- a/terminal-view/build.gradle
+++ b/terminal-view/build.gradle
@@ -42,7 +42,7 @@ publishing {
         bar(MavenPublication) {
             groupId 'com.termux'
             artifactId 'terminal-view'
-            version project.properties.termuxVersion
+            version "0.112"
             artifact(sourceJar)
             artifact("$buildDir/outputs/aar/terminal-view-release.aar")
         }

--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -55,7 +55,7 @@ publishing {
         bar(MavenPublication) {
             groupId 'com.termux'
             artifactId 'termux-shared'
-            version project.properties.termuxVersion
+            version "0.112"
             artifact(sourceJar)
             artifact("$buildDir/outputs/aar/termux-shared-release.aar")
         }


### PR DESCRIPTION
This only reverts the versioning login change done in a6ae656c since that caused F-Droid bot and Github Packages to fail to pick up new releases. The versions must be bumped directly in `build.gradle` file in future and not through other files like `gradle.properties`.